### PR TITLE
Add ENV hover support for ruby

### DIFF
--- a/lib/peeking.js
+++ b/lib/peeking.js
@@ -7,7 +7,8 @@ const run = function (context) {
   const javascriptreactHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'javascriptreact' }, providers.javascriptHover)
   const typescriptreactHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'typescriptreact' }, providers.javascriptHover)
   const vueHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'vue' }, providers.javascriptHover)
-
+  const rubyHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'ruby' }, providers.rubyHover)
+  
   context.subscriptions.push(javascriptHover)
   context.subscriptions.push(typescriptHover)
   context.subscriptions.push(javascriptreactHover)

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -27,6 +27,31 @@ const javascriptHover = {
   }
 }
 
+const rubyHover = {
+  provideHover: function (document, position, token) {
+    const reg = /ENV\["([A-Z]{1}[A-Z_0123456789]+)"\]/
+    const line = document.lineAt(position).text
+    const matches = line.match(reg)
+
+    if (!matches) {
+      return undefined
+    } else {
+      const key = matches[1]
+
+      const start = line.indexOf(key)
+      const end = start + key.length
+      if (position.character >= start && position.character <= end) {
+        const parsed = helpers.envParsed()
+        const value = parsed[key]
+
+        return new vscode.Hover(value)
+      } else {
+        return undefined
+      }
+    }
+  }
+}
+
 const javascriptCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
@@ -88,5 +113,6 @@ const viewDotenvNew = {
 }
 
 module.exports.javascriptHover = javascriptHover
+module.exports.rubyHover = rubyHover
 module.exports.javascriptCompletion = javascriptCompletion
 module.exports.viewDotenvNew = viewDotenvNew


### PR DESCRIPTION
Adds ENV hovering support for ruby. Hover over the a `ENV["MYVAR"]` statement to see the variable value without having to open your .env file. 

https://github.com/dotenv-org/dotenv-vscode/issues/12