### PR TITLE
Move env completionItems to top of list

### DIFF
--- a/lib/providers.js
+++ b/lib/providers.js
@@ -7,7 +7,7 @@ const javascriptHover = {
     const reg = /process.env.([A-Z]{1}[A-Z_0123456789]+)/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
-    
+
     if (!matches) {
       return undefined
     } else {
@@ -18,6 +18,7 @@ const javascriptHover = {
       if (position.character >= start && position.character <= end) {
         const parsed = helpers.envParsed()
         const value = parsed[key]
+
         return new vscode.Hover(value)
       } else {
         return undefined
@@ -90,6 +91,7 @@ const javascriptCompletion = {
         // item.documentation = value // update with more details
         item.documentation = doc // more details
       }
+
       return item
     })
   }

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -7,7 +7,7 @@ const javascriptHover = {
     const reg = /process.env.([A-Z]{1}[A-Z_0123456789]+)/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
-
+    
     if (!matches) {
       return undefined
     } else {
@@ -18,7 +18,6 @@ const javascriptHover = {
       if (position.character >= start && position.character <= end) {
         const parsed = helpers.envParsed()
         const value = parsed[key]
-
         return new vscode.Hover(value)
       } else {
         return undefined
@@ -71,9 +70,10 @@ const javascriptCompletion = {
         detail: ` ${value}`
       }
       const item = new vscode.CompletionItem(completionItemLabel, vscode.CompletionItemKind.Variable)
-
-      item.insertText = key
-
+      item.insertText = `.${key}`
+      item.filterText = `.${key}` // Match convention of other autocompletes
+      item.range = new vscode.Range(new vscode.Position(position.line, position.character - 1), position) // Picks up '.' character as prefix to fix the scoring it does when sorting
+      item.sortText = '0' // Make this the sortText so that any ENV variables will go to the top of the list above anything else
       if (!value) {
         // do nothing
       } else {
@@ -90,7 +90,6 @@ const javascriptCompletion = {
         // item.documentation = value // update with more details
         item.documentation = doc // more details
       }
-
       return item
     })
   }

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -26,7 +26,7 @@ describe('providers', function () {
 
       const result = providers.javascriptCompletion.provideCompletionItems(document, position)
 
-      assert.equal(result[0].insertText, 'HELLO')
+      assert.equal(result[0].insertText, '.HELLO')
       assert.equal(result[0].label.label, 'HELLO')
       assert.equal(result[0].label.detail, ' World')
     })


### PR DESCRIPTION
I noticed this while I was looking at how the completion items work to get ready to add support to ruby. When I typed `process.env.` there was a bunch of typescript language feature suggestions that showed up first and the env vars were all the way at the bottom. I did some research and was able to make some changes to the completionItems so that the env vars should now always show up at the beginning of the list. See the provided video below for example.

[moveCompletionItemsToTop.webm](https://user-images.githubusercontent.com/17735436/191571851-a9021f2e-d56c-4bcd-a7ba-3b4e244b4fb4.webm)
