### PR TITLE
Python auto complete and hover & misc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to the Official Dotenv VS Code extension will be documented in this file.
 
-## [Unreleased](https://github.com/dotenv-org/dotenv-vscode/compare/v0.11.1...master)
+## [Unreleased](https://github.com/dotenv-org/dotenv-vscode/compare/v0.12.0...master)
 
+## 0.12.0
+
+### Added
+
+* Added support for Python autocomplete and secret peeking[#38](https://github.com/dotenv-org/dotenv-vscode/pull/38)
 ## 0.11.1
 
 ### Changed

--- a/lib/autocompletion.js
+++ b/lib/autocompletion.js
@@ -9,6 +9,7 @@ const run = function (context) {
   const vue = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'vue' }, providers.javascriptCompletion, '.')
   const ruby = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'ruby' }, providers.rubyCompletion, '[')
   const python = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'python' }, providers.pythonCompletion, '(')
+  const pythonArray = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'python' }, providers.pythonArrayCompletion, '[')
 
   context.subscriptions.push(javascript)
   context.subscriptions.push(typescript)
@@ -17,6 +18,7 @@ const run = function (context) {
   context.subscriptions.push(vue)
   context.subscriptions.push(ruby)
   context.subscriptions.push(python)
+  context.subscriptions.push(pythonArray)
 
   return true
 }

--- a/lib/autocompletion.js
+++ b/lib/autocompletion.js
@@ -8,6 +8,7 @@ const run = function (context) {
   const typescriptreact = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'typescriptreact' }, providers.javascriptCompletion, '.')
   const vue = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'vue' }, providers.javascriptCompletion, '.')
   const ruby = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'ruby' }, providers.rubyCompletion, '[')
+  const python = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'python' }, providers.pythonCompletion, '(')
 
   context.subscriptions.push(javascript)
   context.subscriptions.push(typescript)
@@ -15,6 +16,7 @@ const run = function (context) {
   context.subscriptions.push(typescriptreact)
   context.subscriptions.push(vue)
   context.subscriptions.push(ruby)
+  context.subscriptions.push(python)
 
   return true
 }

--- a/lib/peeking.js
+++ b/lib/peeking.js
@@ -8,6 +8,7 @@ const run = function (context) {
   const typescriptreactHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'typescriptreact' }, providers.javascriptHover)
   const vueHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'vue' }, providers.javascriptHover)
   const rubyHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'ruby' }, providers.rubyHover)
+  const pythonHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'python' }, providers.pythonHover)
 
   context.subscriptions.push(javascriptHover)
   context.subscriptions.push(typescriptHover)
@@ -15,6 +16,7 @@ const run = function (context) {
   context.subscriptions.push(typescriptreactHover)
   context.subscriptions.push(vueHover)
   context.subscriptions.push(rubyHover)
+  context.subscriptions.push(pythonHover)
 
   return true
 }

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -29,7 +29,7 @@ const javascriptHover = {
 
 const rubyHover = {
   provideHover: function (document, position, token) {
-    const reg = /ENV\["([A-Z]{1}[A-Z_0123456789]+)"\]/
+    const reg = /ENV\[['"]([A-Z]{1}[A-Z_0123456789]+)['"]\]/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
 

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -4,7 +4,7 @@ const helpers = require('./helpers')
 
 const javascriptHover = {
   provideHover: function (document, position, token) {
-    const reg = /process.env.([A-Z]{1}[A-Z_0123456789]+)/
+    const reg = /process\.env\.([A-Z]{1}[A-Z_0123456789]+)/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
 
@@ -30,6 +30,31 @@ const javascriptHover = {
 const rubyHover = {
   provideHover: function (document, position, token) {
     const reg = /ENV\["([A-Z]{1}[A-Z_0123456789]+)"\]/
+    const line = document.lineAt(position).text
+    const matches = line.match(reg)
+
+    if (!matches) {
+      return undefined
+    } else {
+      const key = matches[1]
+
+      const start = line.indexOf(key)
+      const end = start + key.length
+      if (position.character >= start && position.character <= end) {
+        const parsed = helpers.envParsed()
+        const value = parsed[key]
+
+        return new vscode.Hover(value)
+      } else {
+        return undefined
+      }
+    }
+  }
+}
+
+const pythonHover = {
+  provideHover: function (document, position, token) {
+    const reg = /os\.environ\.get\(['"]([A-Z]{1}[A-Z_0123456789]+)['"]\)/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
 
@@ -163,3 +188,4 @@ module.exports.rubyHover = rubyHover
 module.exports.javascriptCompletion = javascriptCompletion
 module.exports.viewDotenvNew = viewDotenvNew
 module.exports.rubyCompletion = rubyCompletion
+module.exports.pythonHover = pythonHover

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -233,7 +233,7 @@ const pythonArrayCompletion = {
       const item = new vscode.CompletionItem(completionItemLabel, vscode.CompletionItemKind.Variable)
       item.insertText = `["${key}"`
       item.filterText = `["${key}"`
-      item.range = new vscode.Range(new vscode.Position(position.line, position.character - 1), position) // Picks up '(' character as prefix to fix the scoring it does when sorting
+      item.range = new vscode.Range(new vscode.Position(position.line, position.character - 1), position) // Picks up '[' character as prefix to fix the scoring it does when sorting
       item.sortText = '0' // Make this the sortText so that any ENV variables will go to the top of the list above anything else
       if (!value) {
         // do nothing

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -54,14 +54,14 @@ const rubyHover = {
 
 const pythonHover = {
   provideHover: function (document, position, token) {
-    const reg = /os\.(environ\.get|getenv)\(['"]([A-Z]{1}[A-Z_0123456789]+)['"]\)/
+    const reg = /os\.(?:(?:environ(?:(?:\.get\(["']([A-Z]{1}[A-Z_0123456789]+)["']\))|(?:\[["']([A-Z]{1}[A-Z_0123456789]+)["']\])))|(?:getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)))/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
 
     if (!matches) {
       return undefined
     } else {
-      const key = matches[2]
+      const key = matches.filter(item => item !== undefined)[1]
 
       const start = line.indexOf(key)
       const end = start + key.length
@@ -212,6 +212,51 @@ const pythonCompletion = {
   }
 }
 
+const pythonArrayCompletion = {
+  provideCompletionItems: function (document, position) {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character)
+    if (!linePrefix.endsWith('os.environ[')) {
+      return undefined
+    }
+
+    const entries = helpers.envEntries()
+
+    return entries.map(function (env) {
+      const key = env[0].trim()
+      const value = env[1].trim()
+
+      // https://code.visualstudio.com/api/references/vscode-api#CompletionItemLabel
+      const completionItemLabel = {
+        label: key,
+        detail: ` ${value}`
+      }
+      const item = new vscode.CompletionItem(completionItemLabel, vscode.CompletionItemKind.Variable)
+      item.insertText = `["${key}"`
+      item.filterText = `["${key}"`
+      item.range = new vscode.Range(new vscode.Position(position.line, position.character - 1), position) // Picks up '(' character as prefix to fix the scoring it does when sorting
+      item.sortText = '0' // Make this the sortText so that any ENV variables will go to the top of the list above anything else
+      if (!value) {
+        // do nothing
+      } else {
+        const s = `.env
+<hr/>
+
+**${key}**
+
+<pre><code>${value}</code></pre>
+`
+        const doc = new vscode.MarkdownString(s)
+        doc.value = s
+        doc.supportHtml = true
+        // item.documentation = value // update with more details
+        item.documentation = doc // more details
+      }
+
+      return item
+    })
+  }
+}
+
 const viewDotenvNew = {
   refresh: function () {
     return null
@@ -234,4 +279,5 @@ module.exports.pythonHover = pythonHover
 module.exports.javascriptCompletion = javascriptCompletion
 module.exports.rubyCompletion = rubyCompletion
 module.exports.pythonCompletion = pythonCompletion
+module.exports.pythonArrayCompletion = pythonArrayCompletion
 module.exports.viewDotenvNew = viewDotenvNew

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -167,6 +167,51 @@ const rubyCompletion = {
   }
 }
 
+const pythonCompletion = {
+  provideCompletionItems: function (document, position) {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character)
+    if (!linePrefix.endsWith('os.environ.get(')) {
+      return undefined
+    }
+
+    const entries = helpers.envEntries()
+
+    return entries.map(function (env) {
+      const key = env[0].trim()
+      const value = env[1].trim()
+
+      // https://code.visualstudio.com/api/references/vscode-api#CompletionItemLabel
+      const completionItemLabel = {
+        label: key,
+        detail: ` ${value}`
+      }
+      const item = new vscode.CompletionItem(completionItemLabel, vscode.CompletionItemKind.Variable)
+      item.insertText = `("${key}"`
+      item.filterText = `("${key}"`
+      item.range = new vscode.Range(new vscode.Position(position.line, position.character - 1), position) // Picks up '(' character as prefix to fix the scoring it does when sorting
+      item.sortText = '0' // Make this the sortText so that any ENV variables will go to the top of the list above anything else
+      if (!value) {
+        // do nothing
+      } else {
+        const s = `.env
+<hr/>
+
+**${key}**
+
+<pre><code>${value}</code></pre>
+`
+        const doc = new vscode.MarkdownString(s)
+        doc.value = s
+        doc.supportHtml = true
+        // item.documentation = value // update with more details
+        item.documentation = doc // more details
+      }
+
+      return item
+    })
+  }
+}
+
 const viewDotenvNew = {
   refresh: function () {
     return null
@@ -185,7 +230,8 @@ const viewDotenvNew = {
 
 module.exports.javascriptHover = javascriptHover
 module.exports.rubyHover = rubyHover
-module.exports.javascriptCompletion = javascriptCompletion
-module.exports.viewDotenvNew = viewDotenvNew
-module.exports.rubyCompletion = rubyCompletion
 module.exports.pythonHover = pythonHover
+module.exports.javascriptCompletion = javascriptCompletion
+module.exports.rubyCompletion = rubyCompletion
+module.exports.pythonCompletion = pythonCompletion
+module.exports.viewDotenvNew = viewDotenvNew

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -54,14 +54,14 @@ const rubyHover = {
 
 const pythonHover = {
   provideHover: function (document, position, token) {
-    const reg = /os\.environ\.get\(['"]([A-Z]{1}[A-Z_0123456789]+)['"]\)/
+    const reg = /os\.(environ\.get|getenv)\(['"]([A-Z]{1}[A-Z_0123456789]+)['"]\)/
     const line = document.lineAt(position).text
     const matches = line.match(reg)
 
     if (!matches) {
       return undefined
     } else {
-      const key = matches[1]
+      const key = matches[2]
 
       const start = line.indexOf(key)
       const end = start + key.length
@@ -170,7 +170,7 @@ const rubyCompletion = {
 const pythonCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
-    if (!linePrefix.endsWith('os.environ.get(')) {
+    if (!linePrefix.endsWith('os.environ.get(') && !linePrefix.endsWith('os.getenv(')) {
       return undefined
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotenv-vscode",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dotenv-vscode",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.0.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dotenv Official +Vault",
   "description": "Official Dotenv. Auto-cloaking, auto-completion, in-code secret peeking, and more.",
   "author": "Mot @motdotla",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "license": "MIT",
   "homepage": "https://github.com/dotenv-org/dotenv-vscode",
   "icon": "dotenv.png",

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -57,20 +57,42 @@ describe('providers', function () {
   })
 
   describe('#pythonCompletion', function () {
-    it('returns undefined at line 0 and wrong position', async function () {
+    it('returns undefined at line 0 and wrong position for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(1, 19)
+      const position = new vscode.Position(2, 19)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
       assert.equal(result, undefined)
     })
 
-    it('returns value at line 1 and correct position', async function () {
+    it('returns value at line 1 and correct position for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(1, 21)
+      const position = new vscode.Position(2, 21)
+
+      const result = providers.pythonCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result[0].insertText, '("HELLO"')
+      assert.equal(result[0].label.label, 'HELLO')
+      assert.equal(result[0].label.detail, ' World')
+    })
+
+    it('returns undefined at line 0 and wrong position for os.getenvformat', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(3, 13)
+
+      const result = providers.pythonCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at line 1 and correct position for os.getenv format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(3, 16)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
@@ -125,7 +147,7 @@ describe('providers', function () {
   })
 
   describe('#pythonHover', function () {
-    it('returns undefined at 0 line', async function () {
+    it('returns undefined at 0 line for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
       const position = new vscode.Position(0, 19)
@@ -135,10 +157,30 @@ describe('providers', function () {
       assert.equal(result, undefined)
     })
 
-    it('returns value at 0 line and correct position', async function () {
+    it('returns value at 0 line and correct position for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
       const position = new vscode.Position(0, 23)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result.contents[0], 'World')
+    })
+
+    it('returns undefined at 0 line for os.getenv format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(1, 13)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at 0 line and correct position for os.getenv format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(1, 17)
 
       const result = providers.pythonHover.provideHover(document, position)
 

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -60,7 +60,7 @@ describe('providers', function () {
     it('returns undefined at line 0 and wrong position for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(2, 19)
+      const position = new vscode.Position(3, 19)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
@@ -70,7 +70,7 @@ describe('providers', function () {
     it('returns value at line 1 and correct position for os.environ.get format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(2, 21)
+      const position = new vscode.Position(3, 21)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
@@ -79,10 +79,10 @@ describe('providers', function () {
       assert.equal(result[0].label.detail, ' World')
     })
 
-    it('returns undefined at line 0 and wrong position for os.getenvformat', async function () {
+    it('returns undefined at line 0 and wrong position for os.getenv format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(3, 13)
+      const position = new vscode.Position(4, 13)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
@@ -92,11 +92,33 @@ describe('providers', function () {
     it('returns value at line 1 and correct position for os.getenv format', async function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
-      const position = new vscode.Position(3, 16)
+      const position = new vscode.Position(4, 16)
 
       const result = providers.pythonCompletion.provideCompletionItems(document, position)
 
       assert.equal(result[0].insertText, '("HELLO"')
+      assert.equal(result[0].label.label, 'HELLO')
+      assert.equal(result[0].label.detail, ' World')
+    })
+
+    it('returns undefined at line 0 and wrong position for os.environ[] format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(5, 15)
+
+      const result = providers.pythonArrayCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at line 1 and correct position for os.environ[] format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(5, 17)
+
+      const result = providers.pythonArrayCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result[0].insertText, '["HELLO"')
       assert.equal(result[0].label.label, 'HELLO')
       assert.equal(result[0].label.detail, ' World')
     })
@@ -181,6 +203,26 @@ describe('providers', function () {
       const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
       const document = await vscode.workspace.openTextDocument(pythonFile)
       const position = new vscode.Position(1, 17)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result.contents[0], 'World')
+    })
+
+    it('returns undefined at 0 line for os.environ[] format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(2, 14)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at 0 line and correct position for os.environ[] format', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(2, 18)
 
       const result = providers.pythonHover.provideHover(document, position)
 

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -99,4 +99,26 @@ describe('providers', function () {
       assert.equal(result.contents[0], 'World')
     })
   })
+
+  describe('#pythonHover', function () {
+    it('returns undefined at 0 line', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(0, 19)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at 0 line and correct position', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(0, 23)
+
+      const result = providers.pythonHover.provideHover(document, position)
+
+      assert.equal(result.contents[0], 'World')
+    })
+  })
 })

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -12,7 +12,7 @@ describe('providers', function () {
     it('returns undefined at line 0 and wrong position', async function () {
       const javascriptFile = path.join(__dirname, '..', 'examples', 'javascript.js')
       const document = await vscode.workspace.openTextDocument(javascriptFile)
-      const position = new vscode.Position(0, 22)
+      const position = new vscode.Position(1, 22)
 
       const result = providers.javascriptCompletion.provideCompletionItems(document, position)
 
@@ -36,7 +36,7 @@ describe('providers', function () {
     it('returns undefined at line 0 and wrong position', async function () {
       const rubyFile = path.join(__dirname, '..', 'examples', 'ruby.rb')
       const document = await vscode.workspace.openTextDocument(rubyFile)
-      const position = new vscode.Position(0, 7)
+      const position = new vscode.Position(1, 7)
 
       const result = providers.rubyCompletion.provideCompletionItems(document, position)
 
@@ -51,6 +51,30 @@ describe('providers', function () {
       const result = providers.rubyCompletion.provideCompletionItems(document, position)
 
       assert.equal(result[0].insertText, '["HELLO"')
+      assert.equal(result[0].label.label, 'HELLO')
+      assert.equal(result[0].label.detail, ' World')
+    })
+  })
+
+  describe('#pythonCompletion', function () {
+    it('returns undefined at line 0 and wrong position', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(1, 19)
+
+      const result = providers.pythonCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at line 1 and correct position', async function () {
+      const pythonFile = path.join(__dirname, '..', 'examples', 'python.py')
+      const document = await vscode.workspace.openTextDocument(pythonFile)
+      const position = new vscode.Position(1, 21)
+
+      const result = providers.pythonCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result[0].insertText, '("HELLO"')
       assert.equal(result[0].label.label, 'HELLO')
       assert.equal(result[0].label.detail, ' World')
     })


### PR DESCRIPTION
- Added support for Python autocomplete and hover , including tests. (Three different formats)
  - `os.environ.get("ENV_VAR")`
  - `os.getenv("ENV_VAR")`
  - `os.environ["ENV_VAR"]`
- Also ensured for hovering it works with single quotes as well
- Fixed small bug with javascript hover regex. Periods were not escaped so they were treated as any character. They are now escaped so will only match to the period character
- Added support for single quotes for ruby hover.

https://github.com/dotenv-org/dotenv-vscode/issues/13
https://github.com/dotenv-org/dotenv-vscode/issues/14