### PR TITLE
Cloak color customization and text transparency fix 

### DIFF
--- a/lib/autocloaking.js
+++ b/lib/autocloaking.js
@@ -37,7 +37,7 @@ function hideValues () {
     }
     const newRule = {
       scope,
-      settings: { foreground: '#FF000005' } // set transparency to 0
+      settings: { foreground: '#FF000000' } // set transparency to 0
     }
     newRules.push(newRule) // add new rule
 

--- a/lib/decorations.js
+++ b/lib/decorations.js
@@ -42,6 +42,8 @@ const parse = function (sourceCode) {
 }
 
 const applyDecorations = function (_ctx, editor, patches) {
+  const cloakColor = vscode.workspace.getConfiguration('dotenv').get('cloakColor')
+
   const decorationsArray = patches
     .map(function (patch) {
       const range = new vscode.Range(
@@ -54,7 +56,7 @@ const applyDecorations = function (_ctx, editor, patches) {
           letterSpacing: '-1ch', // squishes them together
           opacity: '0',
           after: {
-            color: 'black',
+            color: cloakColor,
             contentText: `=${patch.maskedText}`
           }
         }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
           "type": "boolean",
           "default": true,
           "description": "Enable auto-cloaking for your .env files"
+        },
+        "dotenv.cloakColor": {
+          "scope": "resource",
+          "type": "string",
+          "default": "#000000",
+          "description": "Change the color of the cloak for your .env files"
         }
       }
     },


### PR DESCRIPTION
Adds cloak color customization, via the `dotenv.cloakColor` setting. Defaults to the original black color. 