### PR TITLE
Remove .NET support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to the Official Dotenv VS Code extension will be documented in this file.
 
-## [Unreleased](https://github.com/dotenv-org/dotenv-vscode/compare/v0.18.0...master)
+## [Unreleased](https://github.com/dotenv-org/dotenv-vscode/compare/v0.19.0...master)
+
+## 0.19.0
+
+### Removed
+
+* Remove support for .NET dotenv lib [#61](https://github.com/dotenv-org/dotenv-vscode/pull/61)
 
 ## 0.18.0
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Multiple languages supported.
 * Go
 * Java
 * C#
-* .NET
 * Rust
 
 <hr/>
@@ -101,7 +100,6 @@ Multiple languages supported.
 * Go
 * Java
 * C#
-* .NET
 * Rust
 
 <hr/>

--- a/lib/autocompletion.js
+++ b/lib/autocompletion.js
@@ -15,7 +15,6 @@ const run = function (context) {
   const go = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'go' }, providers.goCompletion, '(')
   const java = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, providers.javaCompletion, '(')
   const csharp = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'csharp' }, providers.csharpCompletion, '(')
-  const dotNet = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'csharp' }, providers.dotNetCompletion, '[')
   const rust = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'rust' }, providers.rustCompletion, '(')
 
   context.subscriptions.push(javascript)
@@ -31,7 +30,6 @@ const run = function (context) {
   context.subscriptions.push(go)
   context.subscriptions.push(java)
   context.subscriptions.push(csharp)
-  context.subscriptions.push(dotNet)
   context.subscriptions.push(rust)
 
   return true

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,7 +35,7 @@ function hover (language, document, position) {
     php: /(?:(?:\$_(?:SERVER|ENV)\[["']([A-Z]{1}[A-Z_0123456789]+)["']\])|(?:getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)))/,
     go: /os.Getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     java: /dotenv.get\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
-    csharp: /(?:Environment.GetEnvironmentVariable\(["']([A-Z]{1}[A-Z_0123456789]+)["']\))|(?:envVars\[["']([A-Z]{1}[A-Z_0123456789]+)["']\])/,
+    csharp: /Environment.GetEnvironmentVariable\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     rust: /std::env::var\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/
   }
   const reg = regexDict[language]

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -149,17 +149,6 @@ const csharpCompletion = {
   }
 }
 
-const dotNetCompletion = {
-  provideCompletionItems: function (document, position) {
-    const linePrefix = document.lineAt(position).text.slice(0, position.character)
-    if (!linePrefix.endsWith('envVars[')) {
-      return undefined
-    }
-
-    return helpers.autocomplete('[', document, position)
-  }
-}
-
 const rustCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
@@ -204,6 +193,5 @@ module.exports.phpGetEnvCompletion = phpGetEnvCompletion
 module.exports.goCompletion = goCompletion
 module.exports.javaCompletion = javaCompletion
 module.exports.csharpCompletion = csharpCompletion
-module.exports.dotNetCompletion = dotNetCompletion
 module.exports.rustCompletion = rustCompletion
 module.exports.viewDotenvNew = viewDotenvNew

--- a/test/suite/examples/csharp.cs
+++ b/test/suite/examples/csharp.cs
@@ -1,4 +1,2 @@
 Environment.GetEnvironmentVariable("HELLO")
 Environment.GetEnvironmentVariable(
-envVars["HELLO"]
-envVars[

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -264,30 +264,6 @@ describe('providers', function () {
     })
   })
 
-  describe('#dotNetCompletion', function () {
-    it('returns undefined at line 0 and wrong position', async function () {
-      const csharpFile = path.join(__dirname, '..', 'examples', 'csharp.cs')
-      const document = await vscode.workspace.openTextDocument(csharpFile)
-      const position = new vscode.Position(3, 6)
-
-      const result = providers.dotNetCompletion.provideCompletionItems(document, position)
-
-      assert.equal(result, undefined)
-    })
-
-    it('returns value at line 1 and correct position', async function () {
-      const csharpFile = path.join(__dirname, '..', 'examples', 'csharp.cs')
-      const document = await vscode.workspace.openTextDocument(csharpFile)
-      const position = new vscode.Position(3, 8)
-
-      const result = providers.dotNetCompletion.provideCompletionItems(document, position)
-
-      assert.equal(result[0].insertText, '["HELLO"')
-      assert.equal(result[0].label.label, 'HELLO')
-      assert.equal(result[0].label.detail, ' World')
-    })
-  })
-
   describe('#rustCompletion', function () {
     it('returns undefined at line 0 and wrong position', async function () {
       const rustFile = path.join(__dirname, '..', 'examples', 'rust.rs')
@@ -539,28 +515,6 @@ describe('providers', function () {
       const csharpFile = path.join(__dirname, '..', 'examples', 'csharp.cs')
       const document = await vscode.workspace.openTextDocument(csharpFile)
       const position = new vscode.Position(0, 37)
-
-      const result = providers.csharpHover.provideHover(document, position)
-
-      assert.equal(result.contents[0], 'World')
-    })
-  })
-
-  describe('#dotNetHover', function () {
-    it('returns undefined at 0 line', async function () {
-      const csharpFile = path.join(__dirname, '..', 'examples', 'csharp.cs')
-      const document = await vscode.workspace.openTextDocument(csharpFile)
-      const position = new vscode.Position(2, 6)
-
-      const result = providers.csharpHover.provideHover(document, position)
-
-      assert.equal(result, undefined)
-    })
-
-    it('returns value at 0 line and correct position', async function () {
-      const csharpFile = path.join(__dirname, '..', 'examples', 'csharp.cs')
-      const document = await vscode.workspace.openTextDocument(csharpFile)
-      const position = new vscode.Position(2, 12)
 
       const result = providers.csharpHover.provideHover(document, position)
 


### PR DESCRIPTION
There was an issue with Microsoft's store thinking the .NET code is malicious. 

Removing in order to move forward with other language support.

I ran a test here https://www.virustotal.com/gui/file/55051078bcc8fadb98f4fe3a24dd53703a767023108f109f1c99a9e2f7a4989d/detection and it passed with no issues.