### PR TITLE
Dart support, .env.fat added, fix new file langauge selection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to the Official Dotenv VS Code extension will be documented 
 
 ## 0.22.0
 
-### Changed
+### Added
 
 * [#78](https://github.com/dotenv-org/dotenv-vscode/pull/78)
 * Added autocomplete and hover support for dart.
 * Added .env.fat to list of files that will automatically be configured for dotEnv syntax highlighting.
+
+### Fixed
+* Issue where creating a new file and selecting javascript/ruby/python/php language but highlithing would be in .env style resolved.
 
 ## 0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Official Dotenv VS Code extension will be documented 
 
 ## [Unreleased](https://github.com/dotenv-org/dotenv-vscode/compare/v0.21.0...master)
 
+## 0.22.0
+
+### Changed
+
+* [#78](https://github.com/dotenv-org/dotenv-vscode/pull/78)
+* Added autocomplete and hover support for dart.
+* Added .env.fat to list of files that will automatically be configured for dotEnv syntax highlighting.
+
 ## 0.21.0
 
 ### Changed

--- a/lib/autocompletion.js
+++ b/lib/autocompletion.js
@@ -16,6 +16,7 @@ const run = function (context) {
   const java = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, providers.javaCompletion, '(')
   const csharp = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'csharp' }, providers.csharpCompletion, '(')
   const rust = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'rust' }, providers.rustCompletion, '(')
+  const dart = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'dart' }, providers.dartCompletion, '(')
 
   context.subscriptions.push(javascript)
   context.subscriptions.push(typescript)
@@ -31,7 +32,7 @@ const run = function (context) {
   context.subscriptions.push(java)
   context.subscriptions.push(csharp)
   context.subscriptions.push(rust)
-
+  context.subscriptions.push(dart)
   return true
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,7 +36,8 @@ function hover (language, document, position) {
     go: /os.Getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     java: /dotenv.get\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     csharp: /Environment.GetEnvironmentVariable\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
-    rust: /std::env::(?:var|var_os)\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/
+    rust: /std::env::(?:var|var_os)\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
+    dart: /String.fromEnvironment\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/
   }
   const reg = regexDict[language]
   const line = document.lineAt(position).text

--- a/lib/peeking.js
+++ b/lib/peeking.js
@@ -14,6 +14,7 @@ const run = function (context) {
   const javaHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'java' }, providers.javaHover)
   const csharpHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'csharp' }, providers.csharpHover)
   const rustHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'rust' }, providers.rustHover)
+  const dartHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'dart' }, providers.dartHover)
 
   context.subscriptions.push(javascriptHover)
   context.subscriptions.push(typescriptHover)
@@ -27,6 +28,7 @@ const run = function (context) {
   context.subscriptions.push(javaHover)
   context.subscriptions.push(csharpHover)
   context.subscriptions.push(rustHover)
+  context.subscriptions.push(dartHover)
   return true
 }
 

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -50,6 +50,12 @@ const rustHover = {
   }
 }
 
+const dartHover = {
+  provideHover: function (document, position, token) {
+    return helpers.hover('dart', document, position)
+  }
+}
+
 const javascriptCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
@@ -160,6 +166,17 @@ const rustCompletion = {
   }
 }
 
+const dartCompletion = {
+  provideCompletionItems: function (document, position) {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character)
+    if (!linePrefix.endsWith('String.fromEnvironment(')) {
+      return undefined
+    }
+
+    return helpers.autocomplete('(', document, position)
+  }
+}
+
 const viewDotenvNew = {
   refresh: function () {
     return null
@@ -184,6 +201,7 @@ module.exports.goHover = goHover
 module.exports.javaHover = javaHover
 module.exports.csharpHover = csharpHover
 module.exports.rustHover = rustHover
+module.exports.dartHover = dartHover
 module.exports.javascriptCompletion = javascriptCompletion
 module.exports.rubyCompletion = rubyCompletion
 module.exports.pythonCompletion = pythonCompletion
@@ -194,4 +212,5 @@ module.exports.goCompletion = goCompletion
 module.exports.javaCompletion = javaCompletion
 module.exports.csharpCompletion = csharpCompletion
 module.exports.rustCompletion = rustCompletion
+module.exports.dartCompletion = dartCompletion
 module.exports.viewDotenvNew = viewDotenvNew

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotenv-vscode",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dotenv-vscode",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.0.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dotenv Official +Vault",
   "description": "Official Dotenv. Auto-cloaking, auto-completion, in-code secret peeking, and more.",
   "author": "Mot @motdotla",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT",
   "homepage": "https://github.com/dotenv-org/dotenv-vscode",
   "icon": "dotenv.png",

--- a/package.json
+++ b/package.json
@@ -91,12 +91,7 @@
           "cloak",
           "mask",
           "hide",
-          "blur",
-          "javascript",
-          "nodejs",
-          "ruby",
-          "python",
-          "php"
+          "blur"
         ],
         "extensions": [
           ".env",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
           ".env.previous",
           ".env.staging.previous",
           ".env.production.previous",
+          ".env.fat",
           ".fart",
           ".vault",
           ".project",

--- a/test/suite/examples/dart.dart
+++ b/test/suite/examples/dart.dart
@@ -1,0 +1,2 @@
+String.fromEnvironment('HELLO')
+String.fromEnvironment(

--- a/test/suite/lib/providers.test.js
+++ b/test/suite/lib/providers.test.js
@@ -310,6 +310,30 @@ describe('providers', function () {
     })
   })
 
+  describe('#dartCompletion', function () {
+    it('returns undefined at line 0 and wrong position', async function () {
+      const dartFile = path.join(__dirname, '..', 'examples', 'dart.dart')
+      const document = await vscode.workspace.openTextDocument(dartFile)
+      const position = new vscode.Position(1, 21)
+
+      const result = providers.dartCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at line 1 and correct position', async function () {
+      const dartFile = path.join(__dirname, '..', 'examples', 'dart.dart')
+      const document = await vscode.workspace.openTextDocument(dartFile)
+      const position = new vscode.Position(1, 23)
+
+      const result = providers.dartCompletion.provideCompletionItems(document, position)
+
+      assert.equal(result[0].insertText, '("HELLO"')
+      assert.equal(result[0].label.label, 'HELLO')
+      assert.equal(result[0].label.detail, ' World')
+    })
+  })
+
   describe('#javascriptHover', function () {
     it('returns undefined at 0 line', async function () {
       const javascriptFile = path.join(__dirname, '..', 'examples', 'javascript.js')
@@ -581,6 +605,28 @@ describe('providers', function () {
       const position = new vscode.Position(2, 22)
 
       const result = providers.rustHover.provideHover(document, position)
+
+      assert.equal(result.contents[0], 'World')
+    })
+  })
+
+  describe('#dartHover', function () {
+    it('returns undefined at 0 line with var format', async function () {
+      const dartFile = path.join(__dirname, '..', 'examples', 'dart.dart')
+      const document = await vscode.workspace.openTextDocument(dartFile)
+      const position = new vscode.Position(0, 21)
+
+      const result = providers.dartHover.provideHover(document, position)
+
+      assert.equal(result, undefined)
+    })
+
+    it('returns value at 0 line and correct position', async function () {
+      const dartFile = path.join(__dirname, '..', 'examples', 'dart.dart')
+      const document = await vscode.workspace.openTextDocument(dartFile)
+      const position = new vscode.Position(0, 27)
+
+      const result = providers.dartHover.provideHover(document, position)
 
       assert.equal(result.contents[0], 'World')
     })


### PR DESCRIPTION
Add support for dart auto-complete and hover, and added .env.fat to list of files that are automatically configured to use dotEnv syntax highlighting.

https://github.com/dotenv-org/dotenv-vscode/issues/76
https://github.com/dotenv-org/dotenv-vscode/issues/52