### PR TITLE
Add support "import.meta.env" for JavaScript/TypeScript

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -29,7 +29,7 @@ function envParsed () {
 
 function hover (language, document, position) {
   const regexDict = {
-    javascript: /process\.env\.([A-Z]{1}[A-Z_0123456789]+)/,
+    javascript: /(?:process|import\.meta)\.env\.([A-Z]{1}[A-Z_0123456789]+)/,
     ruby: /ENV\[['"]([A-Z]{1}[A-Z_0123456789]+)['"]\]/,
     python: /os\.(?:(?:environ(?:(?:\.get\(["']([A-Z]{1}[A-Z_0123456789]+)["']\))|(?:\[["']([A-Z]{1}[A-Z_0123456789]+)["']\])))|(?:getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)))/,
     php: /(?:(?:\$_(?:SERVER|ENV)\[["']([A-Z]{1}[A-Z_0123456789]+)["']\])|(?:getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)))/,

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -65,7 +65,7 @@ const kotlinHover = {
 const javascriptCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
-    if (!linePrefix.endsWith('process.env.')) {
+    if (!linePrefix.endsWith('process.env.') && !linePrefix.endsWith('import.meta.env.')) {
       return undefined
     }
 


### PR DESCRIPTION
The `import.meta` meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, such as the module's URL. 
> Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta

It also contains information about environment variables specially when using with Vite.
> Source: https://vitejs.dev/guide/env-and-mode.html